### PR TITLE
ci: set up build using local cache

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -35,7 +35,6 @@ jobs:
           context: .
           tags: ${{ env.IMAGE_NAME }}:${{ env.TAG }}
           load: true
-          provenance: false
           cache-from: |
             type=local,src=/home/runner/.buildx-cache
             type=registry,ref=${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -41,4 +41,3 @@ jobs:
       - name: Run tests
         run: |
           docker run --rm ${{ env.IMAGE_NAME }}:${{ env.TAG }} tests/test_opticks.sh
-          docker rmi ${{ env.IMAGE_NAME }}:${{ env.TAG }}

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -35,8 +35,21 @@ jobs:
           context: .
           tags: ${{ env.IMAGE_NAME }}:${{ env.TAG }}
           load: true
-          cache-from: ${{ env.IMAGE_NAME }}:latest
-          cache-to: type=inline
+          provenance: false
+          cache-from: |
+            type=local,src=/home/runner/.buildx-cache
+            type=registry,ref=${{ env.IMAGE_NAME }}:latest
+          cache-to: |
+            type=inline
+            type=local,dest=/home/runner/.buildx-cache-new,mode=max
+
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /home/runner/.buildx-cache
+          mv /home/runner/.buildx-cache-new /home/runner/.buildx-cache
 
       - name: Run tests
         run: |


### PR DESCRIPTION
This reverts commit 69d16ac457b87e1d114d8c8f291b875b42766f8e: "ci: clean up PR image tags (#65)"

Let's keep the image on the local server during the active development phase