### PR TITLE
fix: remove opticks submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "opticks"]
-	path = opticks
-	url = https://github.com/bnlnpps/esi-opticks.git


### PR DESCRIPTION
Instead, we install esi-opticks from its github repository