### PR TITLE
fix: freeze ratpac version 3.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN spack -e esi-env env activate \
  && spack -e esi-env env activate --sh --dir /opt/spack/var/spack/environments/esi-env > /etc/profile.d/z10_load_spack_environment.sh
 
 # Install RatPac
-RUN git clone https://github.com/rat-pac/ratpac-two.git \
+RUN git clone -b 3.2.0 https://github.com/rat-pac/ratpac-two.git \
  && cmake ratpac-two -B build \
  && cmake --build build/ --parallel
 


### PR DESCRIPTION
The current main branch in ratpac-two fails due to problems with the external FFTW3 dependency.